### PR TITLE
Add includesPack and loadUserMods properties and cleanup path code

### DIFF
--- a/src/main/kotlin/app/ultradev/hytalegradle/HytaleExtension.kt
+++ b/src/main/kotlin/app/ultradev/hytalegradle/HytaleExtension.kt
@@ -18,6 +18,10 @@ abstract class HytaleExtension @Inject constructor(objects: ObjectFactory) {
     /** Set to true if you want to use the asset editor */
     abstract val includesPack: Property<Boolean>
 
+    /** Load mods from the user's mods folder. This allows you to test mods by
+     * installing them where a normal player would, instead of adding them to
+     * the server manually.*/
+    abstract val loadUserMods: Property<Boolean>
 
     /** Directory to run the server in */
     abstract val runDirectory: DirectoryProperty

--- a/src/main/kotlin/app/ultradev/hytalegradle/HytaleGradlePlugin.kt
+++ b/src/main/kotlin/app/ultradev/hytalegradle/HytaleGradlePlugin.kt
@@ -26,6 +26,7 @@ class HytaleGradlePlugin : Plugin<Project> {
         }))
         ext.allowOp.convention(false)
         ext.includesPack.convention(true)
+        ext.loadUserMods.convention(false)
         ext.runDirectory.convention(project.layout.projectDirectory.dir("run"))
 
         val basePath = ext.basePath.get().asFile.toPath()
@@ -90,6 +91,11 @@ class HytaleGradlePlugin : Plugin<Project> {
                 val mainSourceSet = sourceSets.getByName("main")
                 val mainSourceSetPath = mainSourceSet.resources.srcDirs.first().parentFile.absolutePath
                 args += "--mods=${mainSourceSetPath}"
+            }
+
+            if (ext.loadUserMods.get()) {
+                val userModsPath = (basePath / "UserData" / "Mods").absolutePathString()
+                args += "--mods=${userModsPath}"
             }
 
             t.args(args)


### PR DESCRIPTION
I ported the `includesPack` and `loadUserMods` properties from this [template](https://github.com/Build-9/Hytale-Example-Project) by Darkhax

I also cleaned up the paths code a bit, and changed the `basePath` property to use the `Hytale/` directory instead of `Hytale/install/$patchline/package/game/latest/` because it was needed to support `loadUserMods`