### PR TITLE
Read Hytale Home from Registry on Windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.ultradev"
-version = "1.5.3"
+version = "1.5.4"
 
 repositories {
     mavenCentral()
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation("net.java.dev.jna:jna-platform:5.14.0")
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")

--- a/src/main/kotlin/app/ultradev/hytalegradle/HytaleGradlePlugin.kt
+++ b/src/main/kotlin/app/ultradev/hytalegradle/HytaleGradlePlugin.kt
@@ -7,13 +7,14 @@ import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.JavaExec
 import org.gradle.jvm.tasks.Jar
-import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
+import com.sun.jna.platform.win32.Advapi32Util
+import com.sun.jna.platform.win32.WinReg
 
 class HytaleGradlePlugin : Plugin<Project> {
     override fun apply(project: Project) {
@@ -122,7 +123,11 @@ class HytaleGradlePlugin : Plugin<Project> {
 
     fun detectHytaleHome(): Path {
         val basePath = if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-            val basePath = Path("${System.getenv("APPDATA")}\\Hytale")
+            val basePath = Path(Advapi32Util.registryGetStringValue(
+                WinReg.HKEY_LOCAL_MACHINE,
+                "SOFTWARE\\Hypixel Studios\\Hytale",
+                "GameInstallPath"
+            ))
             if (!basePath.exists()) {
                 error("Could not find Hytale installation.")
             }


### PR DESCRIPTION
The Hytale installer writes the game installation folder to the registry in `HKEY_LOCAL_MACHINE\SOFTWARE\Hypixel Studios\Hytale`.

We should read from there rather than defaulting to `%APPDATA%/Hytale` with the option of a manual override as it is more reliable.